### PR TITLE
Add solidity syntax highlighting directive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Adds solidity syntax directive to .gitattributes to enable in GitHub.